### PR TITLE
Add with_frontmatter option to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Configuration options are optional are placed in `_config.yml` under the `readme
 readme_index:
   enabled:          true
   remove_originals: false
+  with_frontmatter: false
 ```
 
 ### Removing originals


### PR DESCRIPTION
Add with_frontmatter: false to default configuration options in README

@benbalter, could you release `0.3.0` as `with_frontmatter` is working only on master now (https://github.com/LintYourLife/LintYourLife.github.io/blob/master/Gemfile)?

@nickcannariato, @jtnord Will Github Pages use `0.3.0` then? 
https://github.community/t5/GitHub-Pages/README-md-is-not-used-as-an-index-page/td-p/6571